### PR TITLE
Fix print_section for empty sections

### DIFF
--- a/CV_printing_functions.R
+++ b/CV_printing_functions.R
@@ -183,10 +183,14 @@ print_section <- function(cv, section_id, glue_template = "default"){
 
   section_data <- dplyr::filter(cv$entries_data, section == section_id)
 
-  # Take entire entries data frame and removes the links in descending order
+  if (nrow(section_data) == 0) {
+    return(invisible(cv))
+  }
+
+  # Take entire entries data frame and remove the links in descending order
   # so links for the same position are right next to each other in number.
-  for(i in 1:nrow(section_data)){
-    for(col in c('title', 'description_bullets')){
+  for (i in seq_len(nrow(section_data))) {
+    for (col in c('title', 'description_bullets')) {
       strip_res <- sanitize_links(cv, section_data[i, col])
       section_data[i, col] <- strip_res$text
       cv <- strip_res$cv
@@ -195,7 +199,7 @@ print_section <- function(cv, section_id, glue_template = "default"){
 
   print(glue::glue_data(section_data, glue_template))
 
-  invisible(strip_res$cv)
+  invisible(cv)
 }
 
 


### PR DESCRIPTION
## Summary
- handle empty data in `print_section`

## Testing
- `Rscript -e "source('CV_printing_functions.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684693ef2a2c832b823a9f34d03fc4ef