### PR TITLE
Update print_section for empty sections

### DIFF
--- a/CV_printing_functions.R
+++ b/CV_printing_functions.R
@@ -185,6 +185,7 @@ print_section <- function(cv, section_id, glue_template = "default"){
 
   # Take entire entries data frame and removes the links in descending order
   # so links for the same position are right next to each other in number.
+  strip_res <- list(cv = cv, text = NULL)
   for(i in 1:nrow(section_data)){
     for(col in c('title', 'description_bullets')){
       strip_res <- sanitize_links(cv, section_data[i, col])
@@ -195,7 +196,11 @@ print_section <- function(cv, section_id, glue_template = "default"){
 
   print(glue::glue_data(section_data, glue_template))
 
-  invisible(strip_res$cv)
+  if(nrow(section_data) > 0){
+    invisible(strip_res$cv)
+  } else {
+    invisible(cv)
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- fix `print_section` to initialize `strip_res` before loop
- return early if section has zero rows

## Testing
- `R -q -e "source('CV_printing_functions.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846958504c4832b9dc8297555e8b049