### PR TITLE
Add print_section unit test

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,3 @@
+library(testthat)
+
+test_dir('tests/testthat')

--- a/tests/testthat/test-print_section.R
+++ b/tests/testthat/test-print_section.R
@@ -1,0 +1,19 @@
+source('../../CV_printing_functions.R')
+
+cv <- list(
+  entries_data = data.frame(
+    section = 'other',
+    title = 'Title',
+    description_bullets = 'Desc',
+    loc = 'Loc',
+    institution = 'Inst',
+    timeline = 'Time',
+    stringsAsFactors = FALSE
+  ),
+  pdf_mode = FALSE,
+  links = character()
+)
+
+test_that('print_section handles missing section', {
+  expect_error(print_section(cv, 'nonexistent'), NA)
+})


### PR DESCRIPTION
## Summary
- add `tests/testthat/` directory and `test-print_section.R`
- verify that `print_section()` doesn’t error when section is missing
- include a basic `tests/testthat.R` runner

## Testing
- `Rscript tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_6846958a6460832bae6f81ebba7f62fd